### PR TITLE
Allow unicode dictionaries. 

### DIFF
--- a/loremipsum/generator.py
+++ b/loremipsum/generator.py
@@ -288,7 +288,7 @@ class Generator(object):
         self.__words = list()
         for word in words:
             try:
-                word = str(word)
+                word = unicode(word)
             except TypeError:
                 continue
             else:

--- a/loremipsum/generator.py
+++ b/loremipsum/generator.py
@@ -376,7 +376,7 @@ class Generator(object):
         # Finish the sentence off with capitalisation, a period and
         # form it into a string
         sentence = ' '.join(words).capitalize().rstrip(word_delimiter) + '.'
-        return (1, len(words), sentence)
+        return (1, len(words), unicode(sentence))
 
     def generate_sentences(self, amount, start_with_lorem=False):
         """

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -4,7 +4,7 @@ import unittest
 class TestLoremIpsum(unittest.TestCase):
 
     def _test_text(self, text, start_with_lorem=False):
-        self.assertTrue(isinstance(text, str))
+        self.assertTrue(isinstance(text, unicode))
         self.assertEqual(text.startswith('Lorem ipsum'), start_with_lorem)
 
     def _test_get_function(self, function):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -53,7 +53,7 @@ class TestGenerator(unittest.TestCase):
         sentences, words, text = generated
         self.assertTrue(isinstance(sentences, int))
         self.assertTrue(isinstance(words, int))
-        self.assertTrue(isinstance(text, str))
+        self.assertTrue(isinstance(text, unicode))
         self.assertEqual(text.startswith('Lorem ipsum'), start_with_lorem)
 
     def _test_generators(self, method, start_with_lorem=False):


### PR DESCRIPTION
When using dictionary files that are UTF8-encoded the generator raises an Error. I basically just had to change one line in the code. Now I can use the generator with a dictionary file containing i.e. arabic or russian words like this:

``` python
path = '/path/to/my/arabic-utf8.dic'
dictionary = codecs.open(path, "r", "utf-8").readlines()
g = Generator(dictionary=dictionary)
```
