### PR TITLE
Remove distribute dependency that is breaking PIP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ egg = {
     'long_description': long_description,
     'classifiers': module.__classifiers__,
     'keywords': ['lorem', 'ipsum', 'text', 'generator'],
-    'setup_requires': ['distribute'],
-    'install_requires': ['distribute'],
     'packages': [name],
     # 'package_dir': {'': '.'},
     # 'package_data': {'': 'default/*.txt'},


### PR DESCRIPTION
There's no need to reference the distribute as requirement since the setup.py will not work anyway without it. It's breaking my virtualenv's pip with this message:

zipimport.ZipImportError: bad local file header in ~/.virtualenvs/loremipsum/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg

Without the requirement, it installs ok.
