### PR TITLE
fix: handle builtin dictionaries as unicode data, not bytes

### DIFF
--- a/loremipsum/generator.py
+++ b/loremipsum/generator.py
@@ -22,9 +22,8 @@ _SENTENCE_DELIMITERS = ['.', '?', '!']
 # "hello" with a comma next to it)
 _WORD_DELIMITERS = [','] + _SENTENCE_DELIMITERS
 
-_SAMPLE = resource_string(__name__, 'default/sample.txt')
-_DICTIONARY = resource_string(__name__, 'default/dictionary.txt').split()
-
+_SAMPLE = unicode(resource_string(__name__, 'default/sample.txt'), encoding="utf-8")
+_DICTIONARY = unicode(resource_string(__name__, 'default/dictionary.txt'), encoding="utf-8").split()
 _LOREM_IPSUM = 'lorem ipsum dolor sit amet, consecteteur adipiscing elit'
 
 


### PR DESCRIPTION
This prevents the generator from outputting repr() of binary data, resulting in a sequence of b'blahblahs'.
If you plan to release a v1.0.6 on pypi, please consider merging this. It fixes things for py3.
